### PR TITLE
Make unzipping less verbose when grabbing dogscats.zip

### DIFF
--- a/Using_Google_Colab_for_Fastai.ipynb
+++ b/Using_Google_Colab_for_Fastai.ipynb
@@ -536,8 +536,8 @@
       "cell_type": "code",
       "source": [
         "# Get the file from fast.ai URL, unzip it, and put it into the folder 'data'\n",
-        "# Warning: I haven't figured out how to make the unzipping less verbose.\n",
-        "!wget http://files.fast.ai/data/dogscats.zip && unzip dogscats.zip -d data/"
+        "# This uses -qq to make the unzipping less verbose.\n",
+        "!wget http://files.fast.ai/data/dogscats.zip && unzip -qq dogscats.zip -d data/"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
Make unzipping less verbose when grabbing dogscats.zip by passing the -qq arggument to unzip