### PR TITLE
Add steps to install from source

### DIFF
--- a/Using_Google_Colab_for_Fastai.ipynb
+++ b/Using_Google_Colab_for_Fastai.ipynb
@@ -96,17 +96,64 @@
     },
     {
       "metadata": {
-        "id": "2xUyc5QDv2Mo",
+        "id": "iANBzzcB5zT0",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Installing fastai from source\n",
+        "\n",
+        "Installing from pypi is not recommended as mentioned in [fastai-github-readme](https://github.com/fastai/fastai)(due to it's rapid changes and lack of tests) and you don't want to use conda on Google Colab. So here are few steps to install the library from source."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "25w0SMSX6M2q",
         "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 102
+        },
+        "outputId": "bc7e9387-fd7d-499c-e78a-6377ad28b326"
       },
       "cell_type": "code",
       "source": [
-        "# Install fastai\n",
-        "!pip3 install fastai"
+        "%%bash\n",
+        "\n",
+        "# Clone the repo for locally build or update the repo if already exists\n",
+        "\n",
+        "if ! [ -d fastai ]\n",
+        "then\n",
+        "  git clone https://github.com/fastai/fastai.git\n",
+        "fi\n",
+        "\n",
+        "cd fastai\n",
+        "\n",
+        "git pull\n",
+        "\n",
+        "# Install through pip\n",
+        "pip -q install . && echo Successfully Installed Fastai"
       ],
-      "execution_count": 0,
-      "outputs": []
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Already up-to-date.\n",
+            "Successfully Installed Fastai\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "Cloning into 'fastai'...\n",
+            "plotnine 0.4.0 has requirement scipy>=1.0.0, but you'll have scipy 0.19.1 which is incompatible.\n",
+            "torchvision 0.2.1 has requirement pillow>=4.1.1, but you'll have pillow 4.0.0 which is incompatible.\n"
+          ],
+          "name": "stderr"
+        }
+      ]
     },
     {
       "metadata": {


### PR DESCRIPTION
Installing from pypi is not recommended as mentioned by jeremy(due to it's rapid changes) and you don't want to use conda on Google Colab.

So Add steps to install from source